### PR TITLE
Parte 1 da refatoração da triagem

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -117,7 +117,7 @@ class User extends Authenticatable
      */
     public function chamados()
     {
-        return $this->belongsToMany('App\Models\Chamado')
+        return $this->belongsToMany('App\Models\Chamado', 'user_chamado')
             ->withPivot('funcao')
             ->withTimestamps();
     }

--- a/app/Policies/ChamadoPolicy.php
+++ b/app/Policies/ChamadoPolicy.php
@@ -31,19 +31,18 @@ class ChamadoPolicy
      */
     public function view(User $user, Chamado $chamado)
     {
-        // Quem pode ver: o autor, atendentes ou admin
+        /* autor e atendentes */
         foreach ($chamado->users as $u) {
             if ($user->codpes == $u->codpes) {
                 return true;
             }
         }
+        /* admin */
         if(Gate::allows('admin')){
             return true;
         }
-        if($user->codpes == $chamado->atribuido_para){
-            return true;               
-        }
 
+        /* isso aqui tem cara de que pode ser eliminado */
         $atendentes = explode(',', config('chamados.atendentes'));
         return in_array($user->codpes, $atendentes);
     }
@@ -68,7 +67,6 @@ class ChamadoPolicy
      */
     public function update(User $user, Chamado $chamado)
     {
-        // Quem pode ver: o autor, atendentes ou admin
         foreach ($chamado->users as $u) {
             if ($user->codpes == $u->codpes) {
                 return true;
@@ -76,9 +74,6 @@ class ChamadoPolicy
         }
         if(Gate::allows('admin')){
             return true;
-        }
-        if($user->codpes == $chamado->atribuido_para){
-            return true;               
         }
 
         $atendentes = explode(',', config('chamados.atendentes'));

--- a/database/factories/ChamadoFactory.php
+++ b/database/factories/ChamadoFactory.php
@@ -28,25 +28,18 @@ class ChamadoFactory extends Factory
         $predios = Chamado::predios();
         $statuses = Chamado::status();
         $status = $statuses[array_rand($statuses)];
-        $atribuido_em = $atribuido_para = $triagem_por = $fechado_em = null;
-        if ($status == 'Atribuído') {
-            $atribuido_em = $this->faker->dateTime($max = 'now', $timezone = null);
-            $atribuido_para = User::inRandomOrder()->first()->codpes;
-            $triagem_por = User::inRandomOrder()->first()->codpes;
-        } 
+        $fechado_em = null;
 
         if ($status == 'Fechado') {
             $fechado_em = $this->faker->dateTime($max = 'now', $timezone = null);
         }
             return [
                 'assunto'        =>  $this->faker->sentence,
+                'descricao'      =>  $this->faker->sentence,
                 'status'         =>  $status,
                 'complexidade'   =>  $complexidades[array_rand($complexidades)],
                 'fila_id'        =>  Fila::inRandomOrder()->first()->id,
-                'fechado_em'     =>  $fechado_em,
-                'atribuido_em'   =>  $atribuido_em,
-                'atribuido_para' =>  $atribuido_para,
-                'triagem_por'    =>  $triagem_por,
+                'fechado_em'     =>  $fechado_em
             ];
     }
 }

--- a/database/migrations/2020_10_06_135511_create_chamados_table.php
+++ b/database/migrations/2020_10_06_135511_create_chamados_table.php
@@ -20,14 +20,10 @@ class CreateChamadosTable extends Migration
             $table->text('assunto');
 
             /* Campos opcionais do chamado */
+            $table->text('descricao');
             $table->enum('status', ['Triagem', 'Atribuído','Fechado']);
-            $table->dateTime('atribuido_em')->nullable();
             $table->dateTime('fechado_em')->nullable();
-
-            /* Campos da triagem */
             $table->enum('complexidade', ['baixa', 'média','alta'])->nullable();
-            $table->integer('triagem_por')->unsigned()->nullable(); // codpes
-            $table->integer('atribuido_para')->unsigned()->nullable(); // codpes
             $table->json('extras')->nullable();
 
             /* Relacionamentos */

--- a/database/seeders/ChamadoSeeder.php
+++ b/database/seeders/ChamadoSeeder.php
@@ -16,9 +16,9 @@ class ChamadoSeeder extends Seeder
     {
         $chamado = [
             'assunto'        => 'Computador não liga',
+            'descricao'      => 'Saiu fumaça da parte de trás.',
             'status'         => 'Triagem',
             'complexidade'   =>  null,
-            'atribuido_para' =>  User::inRandomOrder()->first()->id,
             'extras'         => '{
                 "predio" : "Administração",
                 "sala"   : "Sala 02",
@@ -31,8 +31,13 @@ class ChamadoSeeder extends Seeder
 
         $cht = Chamado::create($chamado);
         $cht->users()->attach(User::first()->id, ['funcao' => 'Autor']);
+        $cht->users()->attach(User::inRandomOrder()->first()->id, ['funcao' => 'Atribuidor']);
+        $cht->users()->attach(User::inRandomOrder()->first()->id, ['funcao' => 'Atendente']);
         Chamado::factory(10)->create()->each(function ($chamado) {
             $chamado->users()->attach(User::inRandomOrder()->first()->id, ['funcao' => 'Autor']);
         });
+        $cht = Chamado::inRandomOrder()->first();
+        $cht->users()->attach(User::inRandomOrder()->first()->id, ['funcao' => 'Atribuidor']);
+        $cht->users()->attach(User::inRandomOrder()->first()->id, ['funcao' => 'Atendente']);
     }
 }

--- a/resources/views/chamados/partials/index.blade.php
+++ b/resources/views/chamados/partials/index.blade.php
@@ -21,7 +21,7 @@
     <tr>
       <td> {{ $chamado->id }} </td>
       <td> ({{ $chamado->fila->setor->sigla }}) {{ $chamado->fila->nome }}</td>
-      <td> <a href="chamados/{{$chamado->id}}"> {!! $chamado->chamado !!} </a></td>
+      <td> <a href="chamados/{{$chamado->id}}"> {!! $chamado->assunto !!} </a></td>
       <td> @include('chamados.partials.status') </td>
       <td> {{ Carbon\Carbon::parse($chamado->created_at)->format('d/m/Y H:i') }}</td>
     </tr>

--- a/resources/views/chamados/show.blade.php
+++ b/resources/views/chamados/show.blade.php
@@ -41,7 +41,7 @@
             <div class="col-md-4">
 
                 {{-- Painel direito --}}
-                <span class="text-muted">Criado por:</span> {{ $chamado->user->name}} @include('chamados.partials.user-detail', ['user'=>$chamado->user])<br>
+                <span class="text-muted">Criado por:</span> {{ $autor->name}} @include('chamados.partials.user-detail', ['user'=>$autor])<br>
                 <span class="text-muted">Criado em:</span> {{ Carbon\Carbon::parse($chamado->created_at)->format('d/m/Y H:i') }}<br>
 
                 @if(!is_null($chamado->fechado_em))
@@ -59,13 +59,13 @@
 
                     @if($chamado->status == 'Atribuído')
                     <span class="text-muted">Atribuído para</span>:
-                    {{ App\Models\User::getByCodpes($chamado->atribuido_para)['name'] }}<br>
+                    {{ $atendente->name }}<br>
 
                     <span class="text-muted">Complexidade</span>: {{ $chamado->complexidade }}<br>
 
                     <span class="text-muted">Por</span>:
-                    {{ App\Models\User::getByCodpes($chamado->triagem_por)['name'] }}
-                    <span class="text-muted">em</span> {{ Carbon\Carbon::parse($chamado->atribuido_em)->format('d/m/Y H:i') }}<br>
+                    {{ $atribuidor->name }}
+                    <span class="text-muted">em</span> <pre>PEGAR DATA DO USER_CHAMADO</pre><br>
                     @endif
                     @if($chamado->status == 'Triagem')
                     Não atribuído

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,7 +9,6 @@ use App\Http\Controllers\SetorController;
 use App\Http\Controllers\FilaController;
 use App\Http\Controllers\UserController;
 
-
 Route::get('/', [IndexController::class, 'index'])->name('home');
 
 /* Senha única */
@@ -37,10 +36,10 @@ Route::resource('chamados', ChamadoController::class)->except(['create', 'store'
 Route::resource('comentarios/{chamado}/', ComentarioController::class);
 
 Route::get('atender', [ChamadoController::class, 'atender']);
-Route::get('triagem', [ChamadoController::class,'triagem']);
 Route::get('todos', [ChamadoController::class,'todos']);
 Route::get('buscaid', [ChamadoController::class,'buscaid']);
 Route::get('chamados/{chamado}/devolver', [ChamadoController::class,'devolver']);
 
+Route::get('triagem', [ChamadoController::class,'triagem']);
 Route::get('triagem/{chamado}', [ChamadoController::class,'triagemForm']);
 Route::post('triagem/{chamado}', [ChamadoController::class,'triagemStore']);


### PR DESCRIPTION
Agora:
  - `triagem_por` vem do `user_chamado` (Atribuidor)
  - `atribuido_para` vem do `user_chamado` (Atendente)
  - `atribuido_em` vem do `user_chamado` (timestamp)

Outras correções:
  - corrige o acessor do User
  - cuidado com a troca do campo "chamado" por "assunto"

Precisa ver:
  - pegar a hora de criação no `user_chamado`
  - ver direito o que fazer no caso da troca de atendente (por ora, estou entregando o primeiro atendente e o primeiro atribuidor)

Não foi mexido em:
  - app/Http/Controllers/ComentarioController.php
  - resources/views/chamados/triagem.blade.php
  - resources/views/chamados/partials/show-triagem-modal.blade.php
  - resources/views/chamados/form.blade.php