### PR TITLE
corrige erro no modelo Fila que ocorre quando especificamos valores para o campo config no FilaSeeder

### DIFF
--- a/app/Models/Fila.php
+++ b/app/Models/Fila.php
@@ -200,6 +200,17 @@ class Fila extends Model
      */
     public function setConfigAttribute($value)
     {
+        // quando este método é invocado pelo seeder, $value vem como string JSON
+        // quando este método é invocado pelo MVC, $value vem como array
+
+        if (is_string($value)) {
+            $value_decoded = json_decode($value, true); // Decodifica como array associativo
+            if (is_array($value_decoded) && (json_last_error() == JSON_ERROR_NONE)) {
+                // se $value veio como string JSON, vamos utilizar $value_decoded, de modo a poder acessá-lo mais abaixo como array
+                $value = $value_decoded;
+            }
+        }
+
         $v = new \StdClass;
         foreach (config('filas.config.visibilidade') as $key => $val) {
             $v->$key = $value['visibilidade'][$key] ?? 0;


### PR DESCRIPTION
Em app/Models/Fila.php, o método setConfigAttribute dava erro quando se especificava o campo "config" da tabela de filas no FilaSeeder. Isso acontecia porque o parâmetro $value vinha como string JSON pelo FilaSeeder. E o método trata $value como se fosse array.

Quando este método vem pelo MVC, quando o usuário edita as configurações da fila, funciona normalmente, pois $value vem como array.

Então, no início do método, fiz uma checagem: se veio como string JSON, transforma em array, e aí o método funcionará corretamente para os dois casos.