### PR TITLE
Melhora dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,12 +60,14 @@ COPY composer.json composer.lock ./
 
 RUN composer install --no-interaction --no-dev --no-autoloader
 
-COPY . .
+USER root
+COPY --chown=www-data . .
 
 RUN mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache \
     && chown -R www-data:www-data storage bootstrap/cache \
     && chmod -R 775 storage bootstrap/cache
 
+USER www-data
 RUN composer dump-autoload
 
 EXPOSE 80


### PR DESCRIPTION
O Dockerfile anterior salvava os arquivos de uma forma que precisávamos publicar os assets novamente a cada reinício ou rebuild da aplicação.

Acredito que este sirva tanto para o Dokku quanto para docker compose ou qualquer outra coisa que use Dockerfile para o build.